### PR TITLE
(SERVER-3051) Allow current working directory to be specified

### DIFF
--- a/dev-resources/puppetlabs/puppetserver/shell_utils_test/echo_cwd
+++ b/dev-resources/puppetlabs/puppetserver/shell_utils_test/echo_cwd
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo $PWD

--- a/src/clj/puppetlabs/puppetserver/shell_utils.clj
+++ b/src/clj/puppetlabs/puppetserver/shell_utils.clj
@@ -27,7 +27,8 @@
 (def ExecutionOptions
   {(schema/optional-key :args) [schema/Str]
    (schema/optional-key :env) (schema/maybe {schema/Str schema/Str})
-   (schema/optional-key :in) (schema/maybe InputStream)})
+   (schema/optional-key :in) (schema/maybe InputStream)
+   (schema/optional-key :cwd) (schema/maybe schema/Str)})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Internal
@@ -35,14 +36,17 @@
 (def default-execution-options
   {:args []
    :env nil
-   :in nil})
+   :in nil
+   :cwd nil})
 
 (schema/defn ^:always-validate java-exe-options :- ShellUtils$ExecutionOptions
-  [{:keys [env in]} :- ExecutionOptions]
+  [{:keys [env in cwd]} :- ExecutionOptions]
   (let [exe-options (ShellUtils$ExecutionOptions.)]
     (.setStdin exe-options in)
     (when env
       (.setEnv exe-options (ks/mapkeys name env)))
+    (when cwd
+      (.setWorkingDirectory exe-options cwd))
     exe-options))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/java/com/puppetlabs/puppetserver/ShellUtils.java
+++ b/src/java/com/puppetlabs/puppetserver/ShellUtils.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.File;
 import java.util.Map;
 
 public class ShellUtils {
@@ -19,6 +20,7 @@ public class ShellUtils {
         private boolean combineStdoutStderr = false;
         private Map<String, String> env = null;
         private InputStream stdin = null;
+        private String cwd = null;
 
         public boolean getCombineStdoutStderr() {
             return combineStdoutStderr;
@@ -42,6 +44,14 @@ public class ShellUtils {
 
         public void setEnv(Map<String, String> env) {
             this.env = env;
+        }
+
+        public String getWorkingDirectory() {
+            return cwd;
+        }
+
+        public void setWorkingDirectory(String cwd) {
+            this.cwd = cwd;
         }
     }
 
@@ -91,6 +101,12 @@ public class ShellUtils {
 
         // Set up the handlers
         executor.setStreamHandler(streamHandler);
+
+        // Set up cwd
+        String cwd = options.getWorkingDirectory();
+        if (cwd != null) {
+            executor.setWorkingDirectory(new File(cwd));
+        }
 
         Integer exitCode = executor.execute(commandLine, options.getEnv());
 

--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -104,6 +104,13 @@
                              {:in (ByteArrayInputStream.
                                    (.getBytes "foo" "UTF-8"))}))))))
 
+(deftest sets-cwd-correctly
+  (testing "sets current working directory correctly"
+    (let [tmpdir (System/getProperty "java.io.tmpdir")]
+      (is (= (str tmpdir "\n") (:stdout (sh-utils/execute-command
+                                         (script-path "echo_cwd")
+                                         {:cwd tmpdir})))))))
+
 (deftest throws-exception-for-non-absolute-path
   (testing "Commands must be given using absolute paths"
     (is (thrown? IllegalArgumentException


### PR DESCRIPTION
If a cwd is specified, pass it through to the executor. This is necessary so that puppet's generate function doesn't modify the cwd for the entire JRuby process[1].

[1] https://github.com/puppetlabs/puppet/blob/8.5.1/lib/puppet/parser/functions/generate.rb#L34